### PR TITLE
Check hostname with platform instead of os

### DIFF
--- a/check-system.py
+++ b/check-system.py
@@ -1,5 +1,5 @@
 import platform
-import os
 
+print("Retrieving System information...\n")
 print(f"System: {platform.system()}")
-print(f"Hostname: {os.uname()[1]}")
+print(f"Hostname: {platform.node()}")


### PR DESCRIPTION
Slightly more efficient implementation using the platform module that has already been imported to perform the hostname check. 